### PR TITLE
Remove return statement from _parse_category, which is a void and shouldn't return a value

### DIFF
--- a/addons/collision_presets/collision_presets_inspector.gd
+++ b/addons/collision_presets/collision_presets_inspector.gd
@@ -12,4 +12,3 @@ func _parse_category(object, category):
 		var ui = ui_scene.new()
 		ui.set_target(object)
 		add_custom_control(ui)
-	return false


### PR DESCRIPTION
Addon doesn't function in Godot 4.7.dev1, as _parse_category as written returns false by default, but shouldn't, as that function is a void and shouldn't return a value.